### PR TITLE
Add counter standalone home-manager config

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,14 @@
 		nvim-config,
 		...
 		}@inputs : {
+			homeConfigurations = {
+				"kerry@counter" = home-manager.lib.homeManagerConfiguration {
+					stateVersion = "25.05";
+					imports = [
+						./users/kerry/minimal.nix { flakeInputs = inputs; }
+					];
+				};
+			};
 			nixosConfigurations = let
 				specialArgs = {
 					flakeInputs = builtins.removeAttrs inputs [

--- a/users/kerry/default.nix
+++ b/users/kerry/default.nix
@@ -15,7 +15,6 @@
 	home = {
 		username = "kerry";
 		homeDirectory = "/home/kerry";
-		stateVersion = "23.11";
 		packages = with pkgs; [
 			keepassxc
 			gimp

--- a/users/kerry/hosts/lazarus/default.nix
+++ b/users/kerry/hosts/lazarus/default.nix
@@ -1,6 +1,7 @@
 { ... }:
 
 {
+	stateVersion = "23.11";
 	sops = {
 		defaultSopsFile = ./secrets.yaml;
 		defaultSopsFormat = "yaml";

--- a/users/kerry/hosts/panza/default.nix
+++ b/users/kerry/hosts/panza/default.nix
@@ -1,18 +1,6 @@
-{ flakeInputs, ... }:
+{ ... }:
 {
-	# imports = [ flakeInputs.catppuccin.homeModules.catppuccin ];
-	# catppuccin = {
-	# 	cursors.enable = true;
-	# };
-	# gtk = {
-	# 	enable = true;
-	# 	#TODO: resolve this option if noto sans doesn't exist or add a mechanism to
-	# 	# satisfy this dependency
-	# 	font.name = "Noto Sans";
-	# 	font.size = 10;
-	# 	iconTheme.name = "Papirus-Dark";
-	# 	cursorTheme.name = "Catppuccin-Mocha-Dark-Cursors";
-	# };
+	stateVersion = "23.11";
 	sops = {
 		defaultSopsFile = ./secrets.yaml;
 		defaultSopsFormat = "yaml";

--- a/users/kerry/hosts/potato/default.nix
+++ b/users/kerry/hosts/potato/default.nix
@@ -1,6 +1,7 @@
 { ... }:
 
 {
+	stateVersion = "23.11";
 	sops = {
 		defaultSopsFile = ./secrets.yaml;
 		defaultSopsFormat = "yaml";

--- a/users/kerry/minimal.nix
+++ b/users/kerry/minimal.nix
@@ -1,0 +1,13 @@
+{ flakeInputs, ... }:
+
+{
+	imports = [
+		flakeInputs.nvim-config.homeManagerModules.nvim-config
+		flakeInputs.shell-config.homeManagerModules.shell-config
+	];
+	programs.home-manager.enable = true;
+	home = {
+		username = "kerry";
+		homeDirectory = "/home/kerry";
+	};
+}


### PR DESCRIPTION
Add standalone home-manager flake output. Move stateVersion for kerry profiles to host-specific contexts. Add minimal home manager module which counter's is built off of.